### PR TITLE
fix: submodule import with https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cp3-bench"]
 	path = cp3-bench
-	url = git@github.com:CP3-Origins/cp3-bench.git
+	url = https://github.com/CP3-Origins/cp3-bench.git


### PR DESCRIPTION
Change the submodule impoty to use HTTPS as it is publicly available and we don't need SSH or sign-in